### PR TITLE
Upgrade to 0.15.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 __pycache__/
 **/*.pyc
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 
 env:
    global:
-     - CONAN_REFERENCE: "caf/0.15.4"
+     - CONAN_REFERENCE: "caf/0.15.5"
      - CONAN_USERNAME: "actor-framework"
      - CONAN_LOGIN_USERNAME: "sourcedelica"
      - CONAN_CHANNEL: "stable"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 |Platform|Build Status|
 |:----|:----|
-|Linux|[![Travis Build Status](https://travis-ci.org/sourcedelica/conan-caf.svg?branch=bintray_setup)](https://travis-ci.org/sourcedelica/conan-caf)|
-|Windows|[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/8qdaau0pxfn3g58o/branch/bintray_setup?svg=true)](https://ci.appveyor.com/project/sourcedelica/conan-caf/branch/bintray_setup)|
+|Linux|[![Travis Build Status](https://travis-ci.org/sourcedelica/conan-caf.svg?branch=0.15.5-upgrade)](https://travis-ci.org/sourcedelica/conan-caf)|
+|Windows|[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/8qdaau0pxfn3g58o/branch/0.15.5-upgrade?svg=true)](https://ci.appveyor.com/project/sourcedelica/conan-caf/branch/bintray_setup)|
 
 ## Setup
 
@@ -14,15 +14,8 @@ pip install conan
 
 ## Usage
 
-Add a requirement for `caf/version@actor-framework/stable`
+Add a requirement for `caf/0.15.5@actor-framework/stable`
 to your `conanfile.txt` or `conanfile.py`.
-
-Check `conanfile.py` in this repo for the _version_.  It is
-the first attribute in the class definition:
-```
-class CAFConan(ConanFile):
-    version = '0.15.3'
-```
 
 ### Build Options
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
     PYTHON_VERSION: "2.7.8"
     PYTHON_ARCH: "32"
 
-    CONAN_REFERENCE: "caf/0.15.4"
+    CONAN_REFERENCE: "caf/0.15.5"
     CONAN_USERNAME: "actor-framework"
     CONAN_LOGIN_USERNAME: "sourcedelica"
     CONAN_CHANNEL: "stable"

--- a/build.py
+++ b/build.py
@@ -23,12 +23,11 @@ if __name__ == "__main__":
         if force_linux:
             settings['os'] = 'Linux'
 
-        # Support static runtime once PR 590 is in a tagged build
         if system != 'Windows' or settings['compiler.runtime'] in {'MD', 'MDd'}:
             filtered_builds.append([settings, options, env_vars, build_requires])
 
-        # Add one shared library build per compiler (except Windows)
-        if platform_info.system() != 'Windows' and compiler not in compilers:
+        # Add one shared library build per x86_64 compiler (except Windows)
+        if platform_info.system() != 'Windows' and settings['arch'] == 'x86_64' and compiler not in compilers:
             filtered_builds.append([settings, {'caf:shared': True, 'caf:static': False}, env_vars, build_requires])
             compilers.add(compiler)
 

--- a/multi-packager.sh
+++ b/multi-packager.sh
@@ -6,10 +6,12 @@
 # For example:
 #    CONAN_PASSWORD=xxxx ./multi-packager.sh
 
-export CONAN_ARCHS=x86_64
+if [ -z "${CONAN_ARCHS}" ]; then
+    export CONAN_ARCHS=x86_64
+fi
 export CONAN_LOGIN_USERNAME=sourcedelica
 export CONAN_CHANNEL=stable
-export CONAN_REFERENCE=caf/0.15.3
+export CONAN_REFERENCE=caf/0.15.4
 export CONAN_UPLOAD=https://api.bintray.com/conan/actor-framework/actor-framework
 export CONAN_USERNAME=actor-framework
 export CONAN_APPLE_CLANG_VERSIONS=9.0


### PR DESCRIPTION
Upgrade to 0.15.5.  

Also temporarily disable `caf_openssl` on Windows.  [See this Appveyor build](https://ci.appveyor.com/project/sourcedelica/conan-caf/build/1.0.32/job/911ie35k80o3qdlg) for an example.